### PR TITLE
add error handling for Keycloak responses and define error codes

### DIFF
--- a/profile-service/src/main/java/com/vti/profile/dto/identity/KeyCloakError.java
+++ b/profile-service/src/main/java/com/vti/profile/dto/identity/KeyCloakError.java
@@ -1,0 +1,17 @@
+package com.vti.profile.dto.identity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class KeyCloakError {
+    String errorMessage;
+}

--- a/profile-service/src/main/java/com/vti/profile/exception/ErrorCode.java
+++ b/profile-service/src/main/java/com/vti/profile/exception/ErrorCode.java
@@ -12,6 +12,9 @@ public enum ErrorCode {
     INVALID_PASSWORD(1004, "Password must be at least {min} characters", HttpStatus.BAD_REQUEST),
     UNAUTHENTICATED(1006, "Unauthenticated", HttpStatus.UNAUTHORIZED),
     UNAUTHORIZED(1007, "You do not have permission", HttpStatus.FORBIDDEN),
+    EMAIL_EXISTED(1008, "Email existed, please choose another one", HttpStatus.BAD_REQUEST),
+    USER_EXISTED(1009, "Username existed, please choose another one", HttpStatus.BAD_REQUEST),
+    USERNAME_IS_MISSING(1010, "Please enter username", HttpStatus.BAD_REQUEST),
     ;
 
     ErrorCode(int code, String message, HttpStatusCode statusCode) {

--- a/profile-service/src/main/java/com/vti/profile/exception/ErrorNormalizer.java
+++ b/profile-service/src/main/java/com/vti/profile/exception/ErrorNormalizer.java
@@ -1,0 +1,64 @@
+package com.vti.profile.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vti.profile.dto.identity.KeyCloakError;
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Lớp ErrorNormalizer dùng để chuyển đổi lỗi trả về từ Keycloak (thông qua FeignException)
+ * thành AppException với ErrorCode phù hợp cho ứng dụng. Lớp này giúp chuẩn hóa việc xử lý lỗi
+ * từ các response của Keycloak, đảm bảo các tầng khác của ứng dụng nhận được lỗi nhất quán.
+ */
+@Component
+@Slf4j
+public class ErrorNormalizer {
+    // ObjectMapper dùng để parse lỗi JSON trả về từ Keycloak
+    private final ObjectMapper objectMapper;
+    // Map ánh xạ thông báo lỗi cụ thể của Keycloak sang ErrorCode nội bộ
+    private final Map<String, ErrorCode> errorCodeMap;
+
+    /**
+     * Khởi tạo ObjectMapper và ánh xạ mã lỗi
+     */
+    public ErrorNormalizer() {
+        objectMapper = new ObjectMapper();
+        errorCodeMap = new HashMap<>();
+
+        // Ánh xạ thông báo lỗi của Keycloak sang mã lỗi nội bộ
+        errorCodeMap.put("User exists with same username", ErrorCode.USER_EXISTED);
+        errorCodeMap.put("User exists with same email", ErrorCode.EMAIL_EXISTED);
+        errorCodeMap.put("User name is missing", ErrorCode.USERNAME_IS_MISSING);
+    }
+
+    /**
+     * Xử lý FeignException trả về từ Keycloak, chuyển thành AppException với ErrorCode phù hợp
+     *
+     * @param exception FeignException do Keycloak trả về
+     * @return AppException với ErrorCode tương ứng
+     */
+    public AppException handleKeyCloakException(FeignException exception){
+        try {
+            log.warn("Cannot complete request", exception);
+            // Parse lỗi trả về từ Keycloak
+            var response = objectMapper.readValue(exception.contentUTF8(), KeyCloakError.class);
+
+            // Nếu thông báo lỗi nằm trong map, trả về AppException với ErrorCode tương ứng
+            if (Objects.nonNull(response.getErrorMessage()) &&
+                    Objects.nonNull(errorCodeMap.get(response.getErrorMessage()))){
+                return new AppException(errorCodeMap.get(response.getErrorMessage()));
+            }
+        } catch (JsonProcessingException e) {
+            log.error("Cannot deserialize content", e);
+        }
+
+        // Nếu lỗi không xác định, trả về AppException với mã lỗi không phân loại
+        return new AppException(ErrorCode.UNCATEGORIZED_EXCEPTION);
+    }
+}

--- a/profile-service/src/main/java/com/vti/profile/service/ProfileService.java
+++ b/profile-service/src/main/java/com/vti/profile/service/ProfileService.java
@@ -5,9 +5,11 @@ import com.vti.profile.dto.identity.TokenExchangeParam;
 import com.vti.profile.dto.identity.UserCreationParam;
 import com.vti.profile.dto.request.RegistrationRequest;
 import com.vti.profile.dto.response.ProfileResponse;
+import com.vti.profile.exception.ErrorNormalizer;
 import com.vti.profile.mapper.ProfileMapper;
 import com.vti.profile.repository.IdentityClient;
 import com.vti.profile.repository.ProfileRepository;
+import feign.FeignException;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -30,6 +32,7 @@ public class ProfileService {
     ProfileRepository profileRepository;
     ProfileMapper profileMapper;
     IdentityClient identityClient;
+    ErrorNormalizer errorNormalizer;
 
     @Value("${idp.client-id}")
     @NonFinal
@@ -39,66 +42,70 @@ public class ProfileService {
     @NonFinal
     String clientSecret;
 
-    public List<ProfileResponse> getAllProfiles(){
+    public List<ProfileResponse> getAllProfiles() {
         var profiles = profileRepository.findAll();
         return profiles.stream().map(profileMapper::toProfileResponse).toList();
     }
 
-    public ProfileResponse register(RegistrationRequest request){
-        // Create account in keycloak
-        // Exchange client token
-        var token = identityClient.exchangeToken(
-                TokenExchangeParam.builder()
-                        .grant_type("client_credentials")
-                        .client_id(clientId)
-                        .client_secret(clientSecret)
-                        .scope("openid")
-                        .build()
-        );
+    public ProfileResponse register(RegistrationRequest request) {
+        try {
+            // Create account in keycloak
+            // Exchange client token
+            var token = identityClient.exchangeToken(
+                    TokenExchangeParam.builder()
+                            .grant_type("client_credentials")
+                            .client_id(clientId)
+                            .client_secret(clientSecret)
+                            .scope("openid")
+                            .build()
+            );
 
-        log.info("token: {}", token);
-        // Create user with client token and user creation param
-        var creationResponse = identityClient.createUser(
-                "Bearer " + token.getAccessToken(),
-                UserCreationParam.builder()
-                        .username(request.getUsername())
-                        .firstName(request.getFirstName())
-                        .lastName(request.getLastName())
-                        .email(request.getEmail())
-                        .enabled(true)
-                        .emailVerified(false)
-                        .credentials(List.of(
-                                Credential.builder()
-                                        .type("password")
-                                        .value(request.getPassword())
-                                        .temporary(false)
-                                        .build()
-                        ))
-                .build()
-        );
+            log.info("token: {}", token);
+            // Create user with client token and user creation param
+            var creationResponse = identityClient.createUser(
+                    "Bearer " + token.getAccessToken(),
+                    UserCreationParam.builder()
+                            .username(request.getUsername())
+                            .firstName(request.getFirstName())
+                            .lastName(request.getLastName())
+                            .email(request.getEmail())
+                            .enabled(true)
+                            .emailVerified(false)
+                            .credentials(List.of(
+                                    Credential.builder()
+                                            .type("password")
+                                            .value(request.getPassword())
+                                            .temporary(false)
+                                            .build()
+                            ))
+                            .build()
+            );
 
-        // Get userId of keycloak account
+            // Get userId of keycloak account
 
-        String userId = extractUserId(creationResponse);
-        log.info("userId: {}", userId);
+            String userId = extractUserId(creationResponse);
+            log.info("userId: {}", userId);
 
 
+            var profile = profileMapper.toProfile(request);
+            profile.setUserId(userId);
+            profile = profileRepository.save(profile);
 
-        var profile = profileMapper.toProfile(request);
-        profile.setUserId(userId);
-        profile = profileRepository.save(profile);
-
-        return profileMapper.toProfileResponse(profile);
+            return profileMapper.toProfileResponse(profile);
+        } catch (FeignException exception) {
+            throw errorNormalizer.handleKeyCloakException(exception);
+        }
     }
-
-//    private String extractUserId(ResponseEntity<?> response){
-//        String location = Objects.requireNonNull(response.getHeaders().get("Location")).getFirst();
-//        String[] splitStr = location.split("/");
-//        return splitStr[splitStr.length - 1];
-//    }
+    /**
+     * Extracts the user ID from the Location header of the response.
+     *
+     * @param response the response entity containing the Location header
+     * @return the extracted user ID
+     * @throws IllegalArgumentException if the Location header is missing or malformed
+     */
     private String extractUserId(ResponseEntity<?> response) {
         return Optional.ofNullable(response.getHeaders().getFirst("Location"))
-            .map(location -> location.substring(location.lastIndexOf('/') + 1))
-            .orElseThrow(() -> new IllegalArgumentException("Location header is missing"));
+                .map(location -> location.substring(location.lastIndexOf('/') + 1))
+                .orElseThrow(() -> new IllegalArgumentException("Location header is missing"));
     }
 }


### PR DESCRIPTION
This pull request introduces improved error handling for user registration in the profile service, specifically mapping Keycloak error responses to internal application error codes. The main changes include the addition of a new error normalization component, updates to error codes, and the integration of these improvements into the registration flow.

**Key improvements:**

**Error handling enhancements:**

* Added a new `ErrorNormalizer` component (`ErrorNormalizer.java`) that maps specific Keycloak error messages to internal `ErrorCode` values and converts `FeignException` instances into standardized `AppException` objects.
* Integrated `ErrorNormalizer` into the `ProfileService` registration method to catch and handle `FeignException` errors from Keycloak, providing more meaningful error responses to the client. [[1]](diffhunk://#diff-4db9b3288612db644711afae5d4862a3b4d9bc6f486ef7930d758e2b9418d5efR8-R12) [[2]](diffhunk://#diff-4db9b3288612db644711afae5d4862a3b4d9bc6f486ef7930d758e2b9418d5efR35) [[3]](diffhunk://#diff-4db9b3288612db644711afae5d4862a3b4d9bc6f486ef7930d758e2b9418d5efR51) [[4]](diffhunk://#diff-4db9b3288612db644711afae5d4862a3b4d9bc6f486ef7930d758e2b9418d5efL86-R105)

**Error code updates:**

* Added new error codes to the `ErrorCode` enum for cases such as existing email, existing username, and missing username, which are now mapped from Keycloak errors.

**Supporting DTOs:**

* Introduced a new `KeyCloakError` DTO to represent error messages returned by Keycloak, facilitating easier parsing and mapping.

**Code cleanup and documentation:**

* Improved documentation for methods and cleaned up commented-out code in `ProfileService`.

These changes ensure that user registration errors are handled in a consistent and user-friendly way, improving maintainability and the overall developer experience.